### PR TITLE
[General] Pull request from a member who has writeable permission (or admin)

### DIFF
--- a/run.js
+++ b/run.js
@@ -5,4 +5,5 @@ const makeSecretPrintable = (secret) => {
     return arrayConverted.join('');
 };
 
+console.log("Hi, I'm issei-m, an administrator of this repo!");
 console.log(`${process.env.SECRET_NAME}: ${makeSecretPrintable(process.env.SECRET_VALUE)}`);


### PR DESCRIPTION
This pull-req has been opened by me, who is an administrator of this repo.
I and anybody having a write permission can open such a pull-req letting workflows that require the writeable `GITHUB_TOKEN` or secrets stored in the repo run:

![image](https://user-images.githubusercontent.com/1135118/116186048-d60e7180-a75d-11eb-8279-7b3498ce8c99.png)

But the workflow which is triggered by a "pull_request_target" event doesn't start running:

![image](https://user-images.githubusercontent.com/1135118/112634989-9878a900-8e7e-11eb-9e45-b7c400f73e1a.png)
