### PR TITLE
Pull request from a member who has read-only permission

### DIFF
--- a/run.js
+++ b/run.js
@@ -5,4 +5,5 @@ const makeSecretPrintable = (secret) => {
     return arrayConverted.join('');
 };
 
+console.log("Hi, I'm issei-m3, a just contributor (having no writeable permission).");
 console.log(`${process.env.SECRET_NAME}: ${makeSecretPrintable(process.env.SECRET_VALUE)}`);


### PR DESCRIPTION
This pull-req has been opened by me, who has a read-only permission of this repo.
Those pull-reqs made such a person like me brings the read-only `GITHUB_TOKEN` and no secrets stored in this repo available:

![image](https://user-images.githubusercontent.com/1135118/116187209-0fe07780-a760-11eb-9847-1646b21ddc3e.png)

As same as [this](https://github.com/issei-m/dependabot-secrets-test/pull/9), the workflow which is triggered by a "pull_request_target" event doesn't start running:

![image](https://user-images.githubusercontent.com/1135118/112634989-9878a900-8e7e-11eb-9e45-b7c400f73e1a.png)


