### PR TITLE
Pull request from a Dependabot

### DIFF
--- a/run.js
+++ b/run.js
@@ -5,4 +5,5 @@ const makeSecretPrintable = (secret) => {
     return arrayConverted.join('');
 };
 
+console.log("Hi, I'm issei-m2, a bot");
 console.log(`${process.env.SECRET_NAME}: ${makeSecretPrintable(process.env.SECRET_VALUE)}`);


### PR DESCRIPTION
This pull-req has been opened by `issei-m2`, who has a read-only permission of this repo but treated as a bot `dependabot[bot]` on the real world.
It means the pull-reqs opened by me starts the workflow invoked by an event "pull_request_target" of the workflow where the writeable `GITHUB_TOKEN` and secrets of this repo available:

![image](https://user-images.githubusercontent.com/1135118/116190684-0c4fef00-a766-11eb-9657-3e400b167cb9.png)

Besides, the workflow which is triggered by `pull_request` doesn't start running because this event can be invoked only by a non-bot (`issei-m2`, real-world of `dependabot[bot]`) user:

![image](https://user-images.githubusercontent.com/1135118/116191003-8a13fa80-a766-11eb-993b-8372f77ff856.png)

